### PR TITLE
Add missing scripts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script type="module" async="" src="https://embed.launchnotes.io/latest/dist/esm/launchnotes-embed.js"></script>
+    <script nomodule="" async="" src="https://embed.launchnotes.io/latest/dist/esm/launchnotes-embed.js"></script>
     <title>React App</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
   return (
     <div className="App">
       <h2>Pop-up Embed</h2>
-      <button key={'whats-new-launchnotes'} id="#whats-new-launchnotes">Click Me</button>
+      <button key={'whats-new-launchnotes'} id="whats-new-launchnotes">Click Me</button>
       <launchnotes-embed
         project={process.env.PRODUCTION_META}
         token={process.env.PRODUCTION_META_PUBLIC_TOKEN}


### PR DESCRIPTION
Hi there, 

I am trying to embed the Launch Notes Widget into a react app and came across your example (which was very helpful). For some reason, it didn't work right from the start for me. 

On the NPM readme, it says to use the following script when self hosting the widget, but this didn't work either (I think the package needs an update).

```
<script src='node_modules/@launchnotes/embed/dist/launchnotes-embed.js'></script>
```

So instead, I added the following scripts from [here](https://help.launchnotes.com/en/articles/5164335-pop-up-embed).

```
<script type="module" async="" src="https://embed.launchnotes.io/latest/dist/esm/launchnotes-embed.js"></script>
<script nomodule="" async="" src="https://embed.launchnotes.io/latest/dist/esm/launchnotes-embed.js"></script>
```

I also noticed that there was an unnecessary `#` in the ID of the trigger. With these changes, it works for me (granted the project and token is correct). 
